### PR TITLE
Correct misspellings and revise documentation

### DIFF
--- a/ObservableArray-RxSwift.xcodeproj/project.pbxproj
+++ b/ObservableArray-RxSwift.xcodeproj/project.pbxproj
@@ -10,14 +10,12 @@
 		8D8C92EE1C342014006B75DF /* ObservableArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D8C92ED1C342014006B75DF /* ObservableArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8D8C92F51C342015006B75DF /* ObservableArray.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8C92EB1C342014006B75DF /* ObservableArray.framework */; };
 		8D8C92FA1C342015006B75DF /* ObservableArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8C92F91C342015006B75DF /* ObservableArrayTests.swift */; };
-		8D8C93071C34233F006B75DF /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8C93041C34233F006B75DF /* RxSwift.framework */; };
 		8D8C93091C34235A006B75DF /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8C93081C34235A006B75DF /* RxSwift.framework */; };
 		8D8C930D1C3423E1006B75DF /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8C930C1C3423E1006B75DF /* ObservableArray.swift */; };
 		8D8C930E1C3423E1006B75DF /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8C930C1C3423E1006B75DF /* ObservableArray.swift */; };
 		8D8C931A1C3426EE006B75DF /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8C93081C34235A006B75DF /* RxSwift.framework */; };
 		8D8C93241C3428DF006B75DF /* ObservableArray.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8C92CC1C341EE6006B75DF /* ObservableArray.framework */; };
 		8D8C932A1C342907006B75DF /* ObservableArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8C92F91C342015006B75DF /* ObservableArrayTests.swift */; };
-		8D8C932B1C34292A006B75DF /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8C93041C34233F006B75DF /* RxSwift.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,11 +41,10 @@
 		8D8C92ED1C342014006B75DF /* ObservableArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObservableArray.h; sourceTree = "<group>"; };
 		8D8C92EF1C342014006B75DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D8C92F41C342014006B75DF /* ObservableArray-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObservableArray-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8D8C92F91C342015006B75DF /* ObservableArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableArrayTests.swift; sourceTree = "<group>"; };
+		8D8C92F91C342015006B75DF /* ObservableArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ObservableArrayTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8D8C92FB1C342015006B75DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8D8C93041C34233F006B75DF /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = "<group>"; };
 		8D8C93081C34235A006B75DF /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
-		8D8C930C1C3423E1006B75DF /* ObservableArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableArray.swift; sourceTree = "<group>"; };
+		8D8C930C1C3423E1006B75DF /* ObservableArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ObservableArray.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8D8C931F1C3428DF006B75DF /* ObservableArray-Mac-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObservableArray-Mac-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -56,7 +53,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D8C93071C34233F006B75DF /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,7 +78,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D8C93241C3428DF006B75DF /* ObservableArray.framework in Frameworks */,
-				8D8C932B1C34292A006B75DF /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -132,7 +127,6 @@
 		8D8C930B1C3423C5006B75DF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8D8C93041C34233F006B75DF /* RxSwift.framework */,
 				8D8C93081C34235A006B75DF /* RxSwift.framework */,
 			);
 			name = Frameworks;

--- a/ObservableArray/ObservableArray.swift
+++ b/ObservableArray/ObservableArray.swift
@@ -10,15 +10,15 @@ import Foundation
 import RxSwift
 
 public struct ArrayChangeEvent {
-    public let insertedIndeces: [Int]
-    public let deletedIndeces: [Int]
-    public let updatedIndeces: [Int]
+    public let insertedIndices: [Int]
+    public let deletedIndices: [Int]
+    public let updatedIndices: [Int]
 
     private init(inserted: [Int] = [], deleted: [Int] = [], updated: [Int] = []) {
         assert(inserted.count + deleted.count + updated.count > 0)
-        self.insertedIndeces = inserted
-        self.deletedIndeces = deleted
-        self.updatedIndeces = updated
+        self.insertedIndices = inserted
+        self.deletedIndices = deleted
+        self.updatedIndices = updated
     }
 }
 
@@ -61,9 +61,9 @@ extension ObservableArray {
         return eventSubject
     }
 
-    private func arrayDidChanged(event: EventType) {
-        elementsSubject?.on(.Next(self.elements))
-        eventSubject?.on(.Next(event))
+    private func arrayDidChange(event: EventType) {
+        elementsSubject?.oNext(elements)
+        eventSubject?.onNext(event)
     }
 }
 
@@ -88,7 +88,7 @@ extension ObservableArray: RangeReplaceableCollectionType {
 
     public mutating func append(newElement: Element) {
         elements.append(newElement)
-        arrayDidChanged(ArrayChangeEvent(inserted: [elements.count - 1]))
+        arrayDidChange(ArrayChangeEvent(inserted: [elements.count - 1]))
     }
 
     public mutating func appendContentsOf<S : SequenceType where S.Generator.Element == Element>(newElements: S) {
@@ -97,7 +97,7 @@ extension ObservableArray: RangeReplaceableCollectionType {
         guard end != elements.count else {
             return
         }
-        arrayDidChanged(ArrayChangeEvent(inserted: Array(end..<elements.count)))
+        arrayDidChange(ArrayChangeEvent(inserted: Array(end..<elements.count)))
     }
 
     public mutating func appendContentsOf<C : CollectionType where C.Generator.Element == Element>(newElements: C) {
@@ -106,23 +106,23 @@ extension ObservableArray: RangeReplaceableCollectionType {
         }
         let end = elements.count
         elements.appendContentsOf(newElements)
-        arrayDidChanged(ArrayChangeEvent(inserted: Array(end..<elements.count)))
+        arrayDidChange(ArrayChangeEvent(inserted: Array(end..<elements.count)))
     }
 
     public mutating func removeLast() -> Element {
         let e = elements.removeLast()
-        arrayDidChanged(ArrayChangeEvent(deleted: [elements.count]))
+        arrayDidChange(ArrayChangeEvent(deleted: [elements.count]))
         return e
     }
 
     public mutating func insert(newElement: Element, atIndex i: Int) {
         elements.insert(newElement, atIndex: i)
-        arrayDidChanged(ArrayChangeEvent(inserted: [i]))
+        arrayDidChange(ArrayChangeEvent(inserted: [i]))
     }
 
     public mutating func removeAtIndex(index: Int) -> Element {
         let e = elements.removeAtIndex(index)
-        arrayDidChanged(ArrayChangeEvent(deleted: [index]))
+        arrayDidChange(ArrayChangeEvent(deleted: [index]))
         return e
     }
 
@@ -132,7 +132,7 @@ extension ObservableArray: RangeReplaceableCollectionType {
         }
         let es = elements
         elements.removeAll(keepCapacity: keepCapacity)
-        arrayDidChanged(ArrayChangeEvent(deleted: Array(0..<es.count)))
+        arrayDidChange(ArrayChangeEvent(deleted: Array(0..<es.count)))
     }
 
     public mutating func insertContentsOf(newElements: [Element], atIndex i: Int) {
@@ -140,7 +140,7 @@ extension ObservableArray: RangeReplaceableCollectionType {
             return
         }
         elements.insertContentsOf(newElements, at: i)
-        arrayDidChanged(ArrayChangeEvent(inserted: Array(i..<i + newElements.count)))
+        arrayDidChange(ArrayChangeEvent(inserted: Array(i..<i + newElements.count)))
     }
 
     public mutating func replaceRange<C : CollectionType where C.Generator.Element == Element>(subRange: Range<Int>, with newCollection: C) {
@@ -151,14 +151,14 @@ extension ObservableArray: RangeReplaceableCollectionType {
         }
         let newCount = elements.count
         let end = first + (newCount - oldCount) + subRange.count
-        arrayDidChanged(ArrayChangeEvent(inserted: Array(first..<end),
+        arrayDidChange(ArrayChangeEvent(inserted: Array(first..<end),
                                          deleted: Array(subRange)))
     }
 
     public mutating func popLast() -> Element? {
         let e = elements.popLast()
         if e != nil {
-            arrayDidChanged(ArrayChangeEvent(deleted: [elements.count]))
+            arrayDidChange(ArrayChangeEvent(deleted: [elements.count]))
         }
         return e
     }
@@ -184,9 +184,9 @@ extension ObservableArray: CollectionType {
         set {
             elements[index] = newValue
             if index == elements.count {
-                arrayDidChanged(ArrayChangeEvent(inserted: [index]))
+                arrayDidChange(ArrayChangeEvent(inserted: [index]))
             } else {
-                arrayDidChanged(ArrayChangeEvent(updated: [index]))
+                arrayDidChange(ArrayChangeEvent(updated: [index]))
             }
         }
     }
@@ -200,7 +200,7 @@ extension ObservableArray: CollectionType {
             guard let first = bounds.first else {
                 return
             }
-            arrayDidChanged(ArrayChangeEvent(inserted: Array(first..<first + newValue.count),
+            arrayDidChange(ArrayChangeEvent(inserted: Array(first..<first + newValue.count),
                                              deleted: Array(bounds)))
         }
     }

--- a/ObservableArrayTests/ObservableArrayTests.swift
+++ b/ObservableArrayTests/ObservableArrayTests.swift
@@ -127,9 +127,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([2], event.insertedIndeces)
-            XCTAssertTrue(event.deletedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([2], event.insertedIndices)
+            XCTAssertTrue(event.deletedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -140,7 +140,6 @@ class ObservableArrayTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
-
 
     func testAppendContentsOfSeqeunce() {
         var a: ObservableArray<String> = []
@@ -177,9 +176,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([2, 3, 4], event.insertedIndeces)
-            XCTAssertTrue(event.deletedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([2, 3, 4], event.insertedIndices)
+            XCTAssertTrue(event.deletedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -226,9 +225,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([2, 3, 4], event.insertedIndeces)
-            XCTAssertTrue(event.deletedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([2, 3, 4], event.insertedIndices)
+            XCTAssertTrue(event.deletedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -273,9 +272,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([3], event.deletedIndeces)
-            XCTAssertTrue(event.insertedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([3], event.deletedIndices)
+            XCTAssertTrue(event.insertedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -320,9 +319,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([2], event.insertedIndeces)
-            XCTAssertTrue(event.deletedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([2], event.insertedIndices)
+            XCTAssertTrue(event.deletedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -367,9 +366,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([2], event.deletedIndeces)
-            XCTAssertTrue(event.insertedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([2], event.deletedIndices)
+            XCTAssertTrue(event.insertedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -414,9 +413,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([0,1,2,3,4], event.deletedIndeces)
-            XCTAssertTrue(event.insertedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([0,1,2,3,4], event.deletedIndices)
+            XCTAssertTrue(event.insertedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -464,9 +463,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([2,3,4], event.insertedIndeces)
-            XCTAssertTrue(event.deletedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([2,3,4], event.insertedIndices)
+            XCTAssertTrue(event.deletedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -512,9 +511,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([1,2,3], event.insertedIndeces)
-            XCTAssertEqual([1,2], event.deletedIndeces)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([1,2,3], event.insertedIndices)
+            XCTAssertEqual([1,2], event.deletedIndices)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -562,9 +561,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([3], event.deletedIndeces)
-            XCTAssertTrue(event.insertedIndeces.isEmpty)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([3], event.deletedIndices)
+            XCTAssertTrue(event.insertedIndices.isEmpty)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -613,9 +612,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([1], event.updatedIndeces)
-            XCTAssertTrue(event.deletedIndeces.isEmpty)
-            XCTAssertTrue(event.insertedIndeces.isEmpty)
+            XCTAssertEqual([1], event.updatedIndices)
+            XCTAssertTrue(event.deletedIndices.isEmpty)
+            XCTAssertTrue(event.insertedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)
@@ -663,9 +662,9 @@ class ObservableArrayTests: XCTestCase {
 
         let exp = expectationWithDescription("event emitted")
         a.rx_events().subscribeNext { (event) -> Void in
-            XCTAssertEqual([1,2,3], event.insertedIndeces)
-            XCTAssertEqual([1,2], event.deletedIndeces)
-            XCTAssertTrue(event.updatedIndeces.isEmpty)
+            XCTAssertEqual([1,2,3], event.insertedIndices)
+            XCTAssertEqual([1,2], event.deletedIndices)
+            XCTAssertTrue(event.updatedIndices.isEmpty)
             exp.fulfill()
             }
             .addDisposableTo(disposeBag)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # ObservableArray-RxSwift
 
-ObservableArray is an array that can emit messages of elements and diffs on it's changing.
+`ObservableArray` is an array that can emit messages of elements and diffs when it is mutated.
 
 ## Usage
 
@@ -21,7 +21,7 @@ func rx_events() -> Observable<ArrayChangeEvent>
 
 ### `rx_elements`
 
-`rx_elements()` emits own elements on its changing.
+`rx_elements()` emits own elements when mutated.
 
 ```swift
 var array: ObservableArray<String> = ["foo", "bar", "buzz"]
@@ -38,7 +38,7 @@ This will print:
     ["foo", "bar", "milk", "coffee"]
     []
 
-`rx_elements` can be worked with `rx_itemsWithCellIdentifier`:
+`rx_elements` can work with `rx_itemsWithCellIdentifier`:
 
 ```swift
 model.rx_elements()
@@ -53,7 +53,7 @@ model.rx_elements()
 
 ### `rx_events`
 
-`rx_events()` emits `ArrayChangeEvent` that contains indeces of diff on its changing.
+`rx_events()` emits `ArrayChangeEvent` that contains indices of diffs when mutated.
 
 ```swift
 var array: ObservableArray<String> = ["foo", "bar", "buzz"]
@@ -66,36 +66,36 @@ array.removeAll()
 
 This will print:
 
-    ArrayChangeEvent(insertedIndeces: [3], deletedIndeces: [], updatedIndeces: [])
-    ArrayChangeEvent(insertedIndeces: [], deletedIndeces: [], updatedIndeces: [2])
-    ArrayChangeEvent(insertedIndeces: [], deletedIndeces: [0, 1, 2, 3], updatedIndeces: [])
+    ArrayChangeEvent(insertedIndices: [3], deletedIndices: [], updatedIndices: [])
+    ArrayChangeEvent(insertedIndices: [], deletedIndices: [], updatedIndices: [2])
+    ArrayChangeEvent(insertedIndices: [], deletedIndices: [0, 1, 2, 3], updatedIndices: [])
 
-`ArrayChangeEvent` is defined as follows:
+`ArrayChangeEvent` is defined as:
 
 ```swift
 struct ArrayChangeEvent {
-    let insertedIndeces: [Int]
-    let deletedIndeces: [Int]
-    let updatedIndeces: [Int]
+    let insertedIndices: [Int]
+    let deletedIndices: [Int]
+    let updatedIndices: [Int]
 }
 ```
 
-These indeces can be used with methods of table view such like `insertRowsAtIndexPaths`.
-The following code will enable cell animations on its changing.
+These indices can be used with table view methods, such like `insertRowsAtIndexPaths(_:withRowAnimation:)`.
+For example, the following code will enable cell animations when the source array is mutated.
 
 ```swift
 extension UITableView {
     public func rx_autoUpdater(source: Observable<ArrayChangeEvent>) -> Disposable {
         return source
             .scan((0, nil)) { (a: (Int, ArrayChangeEvent!), ev) in
-                return (a.0 + ev.insertedIndeces.count - ev.deletedIndeces.count, ev)
+                return (a.0 + ev.insertedIndices.count - ev.deletedIndices.count, ev)
             }
             .observeOn(MainScheduler.instance)
             .subscribeNext { sourceCount, event in
                 guard let event = event else { return }
 
                 let tableCount = self.numberOfRowsInSection(0)
-                guard tableCount + event.insertedIndeces.count - event.deletedIndeces.count == sourceCount else {
+                guard tableCount + event.insertedIndices.count - event.deletedIndices.count == sourceCount else {
                     self.reloadData()
                     return
                 }
@@ -105,16 +105,16 @@ extension UITableView {
                 }
 
                 self.beginUpdates()
-                self.insertRowsAtIndexPaths(toIndexSet(event.insertedIndeces), withRowAnimation: .Automatic)
-                self.deleteRowsAtIndexPaths(toIndexSet(event.deletedIndeces), withRowAnimation: .Automatic)
-                self.reloadRowsAtIndexPaths(toIndexSet(event.updatedIndeces), withRowAnimation: .Automatic)
+                self.insertRowsAtIndexPaths(toIndexSet(event.insertedIndices), withRowAnimation: .Automatic)
+                self.deleteRowsAtIndexPaths(toIndexSet(event.deletedIndices), withRowAnimation: .Automatic)
+                self.reloadRowsAtIndexPaths(toIndexSet(event.updatedIndices), withRowAnimation: .Automatic)
                 self.endUpdates()
             }
     }
 }
 ```
 
-You can use `rx_autoUpdater` with `bindTo` in your view contollers:
+You can use `rx_autoUpdater(_:)` with `bindTo(_:)` in your view contollers:
 
 ```swift
 model.rx_events()
@@ -123,12 +123,11 @@ model.rx_events()
     .addDisposableTo(disposeBag)
 ```
 
-Unfortunately, `rx_autoUpdater` doesn't work with `rx_elements()` binding to `rx_itemsWithCellIdentifier`, because it uses `reloadData()` internally.
+Unfortunately, `rx_autoUpdater` doesn't work with `rx_elements()` binding to `rx_itemsWithCellIdentifier(_:source:configureCell:cellType:)`, because it uses `reloadData()` internally.
 
 ## Supported Methods
 
-ObservableArray implements the following methods and properties, which just work as the equivallent of an array's one.
-You can use other methods defined in protocol extensions such as `sort`, `reverse` and `enumerate`.
+`ObservableArray` implements the following methods and properties, which work the same way as `Array`'s equivalent methods. You can also use additional `Array` methods defined in protocol extensions, such as `sort`, `reverse` and `enumerate`.
 
 ```swift
 init()
@@ -165,6 +164,10 @@ subscript(bounds: Range<Int>) -> ArraySlice<Element>
 
     pod 'ObservableArray-RxSwift'
 
+**Important**: Use the following `import` statement to import `ObservableArray-RxSwift`:
+
+`import ObservableArray_RxSwift`
+
 ### Carthage
 
     github "safx/ObservableArray-RxSwift"
@@ -172,7 +175,6 @@ subscript(bounds: Range<Int>) -> ArraySlice<Element>
 ### Manual Install
 
 Just copy `ObservableArray.swift` into your project.
-
 
 ## License
 


### PR DESCRIPTION
I corrected misspellings in method names and documentation. These are breaking changes, but I do think it is important to ensure grammatical correctness, so I hope you will accept this PR. I also reworded some documentation.
