### PR TITLE
Switched elementSubject to a BehaviorSubject instead of PublishSubject

### DIFF
--- a/ObservableArray/ObservableArray.swift
+++ b/ObservableArray/ObservableArray.swift
@@ -26,7 +26,7 @@ public struct ObservableArray<Element>: ArrayLiteralConvertible {
     public typealias EventType = ArrayChangeEvent
 
     internal var eventSubject: PublishSubject<EventType>!
-    internal var elementsSubject: PublishSubject<[Element]>!
+    internal var elementsSubject: BehaviorSubject<[Element]>!
     internal var elements: [Element]
 
     public init() {
@@ -49,7 +49,7 @@ public struct ObservableArray<Element>: ArrayLiteralConvertible {
 extension ObservableArray {
     public mutating func rx_elements() -> Observable<[Element]> {
         if elementsSubject == nil {
-            self.elementsSubject = PublishSubject<[Element]>()
+            self.elementsSubject = BehaviorSubject<[Element]>(value: self.elements)
         }
         return elementsSubject
     }


### PR DESCRIPTION
If the ObservableArray elements are set up BEFORE rx_elements() is called and subscribed to, we were not seeing any data. A simple solution was to make elementsSubject a BehaviorSubject instead of a PublishSubject. There is no change if elements is empty when rx_elements() is called.
