### PR TITLE
fix README example code error

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ func rx_events() -> Observable<ArrayChangeEvent>
 
 ```swift
 var array: ObservableArray<String> = ["foo", "bar", "buzz"]
-array.rx_events().subscribeNext { print($0) }
+array.rx_elements().subscribeNext { print($0) }
 
 array.append("coffee")
 array[2] = "milk"


### PR DESCRIPTION
rx_events will print `ArrayChangeEvent`, not the elements
the sample code should use rx_elements 
